### PR TITLE
Fix Array init value.

### DIFF
--- a/algo1.py
+++ b/algo1.py
@@ -32,10 +32,7 @@ class Array:
                         self.size=0
                 else:
                         self.size=size
-                if type(init_value)!=Array:
-                    self.data= [copy.deepcopy(None) for i in range(0,size)]
-                else:
-                    self.data= [copy.deepcopy(init_value) for i in range(0,size)]
+                self.data= [copy.deepcopy(init_value) for i in range(0,size)]
                 self.type = type(init_value)
         def __getitem__(self,index):
                 if index > self.size:


### PR DESCRIPTION
Array init value was not captured during creation.

Old: 
```py
Array(3,4) => [None,None,None] # type int
```
New
```py
Array(3,4) => [4,4,4] # type int
```